### PR TITLE
Cross platform support! (Linux in particular)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 
 var http = require('http')
-var child = require('child_process')
 var findPort = require('find-port')
+var opn = require('opn')
 var rc = module.require('rc')
 var argv = require('optimist').argv
 var config = rc('hcat', {}, argv)
@@ -44,8 +44,7 @@ function cat(port) {
 	var server = http.createServer(handler)
 
 	server.on('listening', function() {
-		var command = (process.platform === 'win32') ? 'start' : 'open'
-		child.exec(command + ' http://127.0.0.1:' + port)
+		opn('http://127.0.0.1:' + port)
 	})
 
 	server.listen(port)

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "url": "https://github.com/kessler/node-hcat"
   },
   "keywords": [
-    "pipe",
     "browser",
     "cat",
-    "hcat"
+    "hcat",
+    "pipe"
   ],
   "author": "Yaniv Kessler",
   "license": "MIT",
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "find-port": "1.0.0",
+    "opn": "^3.0.2",
     "optimist": "~0.6.0",
     "rc": "~0.3.3",
     "text-table": "~0.2.0"


### PR DESCRIPTION
Uses `opn` so that browser launching works nicely on Linux as well as OS X and Windows without needing to look at the current platform and fiddle with it.