### PR TITLE
Use the $BROWSER environment variable, when set.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var http = require('http')
+var spawn = require('child_process').spawn
 var opn = require('opn')
 var rc = module.require('rc')
 var config = rc('hcat', {
@@ -29,7 +30,14 @@ var server = http.createServer();
 server.once('request', handler);
 
 server.on('listening', function() {
-	opn('http://' + config.hostname +':' + server.address().port)
+  var url = 'http://' + config.hostname +':' + server.address().port
+
+  if (!process.env.BROWSER) {
+    console.error('The environment variable $BROWSER is not set. Falling back to default opening mechanism.')
+    opn('http://' + config.hostname +':' + server.address().port)
+  } else {
+    spawn(process.env.BROWSER, [url])
+  }
 })
 
 server.listen(config.port, config.hostname)


### PR DESCRIPTION
Hey there! I really like hcat; I use it almost daily.

After sending this PR, I looked back and realized it was actually me who [originally added Linux support](https://github.com/kessler/node-hcat/commit/bb09c9dcb100c954f7411f454bfec4b908641bb1) a while back, via `opn`.

While great, `opn` uses the XDG Desktop spec to discover what application to use to open a file. This spec is complicated -- certainly much more so than a simple `export BROWSER=foobar` in your relevant RC file.

This pull request maintains backwards compatibility: if you don't have `$BROWSER` set, `opn` will open the URL as it previously did.